### PR TITLE
[TL-2] Enhanced validateTwoDimensionalArray function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "test-logic",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "A collection of often-repeated test assertion patterns that I was tired of typing over and over again!",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -15,13 +15,22 @@ Valid argument array examples:
         * one call with two arguments: [[arg1, arg2]]
         * three calls with two arguments each: [[arg1, arg2], [arg3, arg4], [arg5, arg6]]`;
 
-export const validateTwoDimensionalArray = (testArray: any | any[] | any[]): void | never => {
+export const validateTwoDimensionalArray = (testArray: any | any[] | any[][]): any[][] | never => {
     if (Array.isArray(testArray)) {
-        if (testArray.length === 0) {
-            return;
+        let nonArrayFound = false;
+        let arrayFound = false;
+        for (const item of testArray) {
+            if (Array.isArray(item)) {
+                arrayFound = true;
+            } else {
+                nonArrayFound = true;
+            }
         }
-        if (Array.isArray(testArray[0])) {
-            return;
+        if (!arrayFound) {
+            return [testArray];
+        }
+        if (!nonArrayFound) {
+            return testArray;
         }
     }
     throw new Error(TWO_DIMENSIONAL_ARRAY_ERROR);

--- a/src/testClassMethodUsage.ts
+++ b/src/testClassMethodUsage.ts
@@ -1,4 +1,4 @@
-import { ICalledClassMethodBundle, ICalledFunctionBundle, ITestClassMethodBundle } from './common';
+import { ICalledClassMethodBundle, ICalledFunctionBundle, ITestClassMethodBundle, validateTwoDimensionalArray } from './common';
 
 export class TestClassMethodUsage {
     public static callsFunctionTimesAsync = async (classBundle: ITestClassMethodBundle, calledBundle: ICalledFunctionBundle): Promise<void> => {
@@ -19,19 +19,27 @@ export class TestClassMethodUsage {
         classBundle: ITestClassMethodBundle,
         calledBundle: ICalledFunctionBundle,
     ): Promise<void> => {
+        let expectedArgs;
+        if (calledBundle.expectedArgs) {
+            expectedArgs = validateTwoDimensionalArray(calledBundle.expectedArgs);
+        }
         try {
             await classBundle.classToTest[classBundle.methodName](...classBundle.args);
         } catch {}
-        for (const argSet of calledBundle.expectedArgs || []) {
+        for (const argSet of expectedArgs || []) {
             expect(calledBundle.calledFunction).toHaveBeenCalledWith(...argSet);
         }
         return;
     };
     public static callsFunctionWithArguments = (classBundle: ITestClassMethodBundle, calledBundle: ICalledFunctionBundle): void => {
+        let expectedArgs;
+        if (calledBundle.expectedArgs) {
+            expectedArgs = validateTwoDimensionalArray(calledBundle.expectedArgs);
+        }
         try {
             classBundle.classToTest[classBundle.methodName](...classBundle.args);
         } catch {}
-        for (const argSet of calledBundle.expectedArgs || []) {
+        for (const argSet of expectedArgs || []) {
             expect(calledBundle.calledFunction).toHaveBeenCalledWith(...argSet);
         }
         return;
@@ -56,21 +64,29 @@ export class TestClassMethodUsage {
         classBundle: ITestClassMethodBundle,
         calledBundle: ICalledClassMethodBundle,
     ): Promise<void> => {
+        let expectedArgs;
+        if (calledBundle.expectedArgs) {
+            expectedArgs = validateTwoDimensionalArray(calledBundle.expectedArgs);
+        }
         const methodSpy = jest.spyOn(calledBundle.calledClass, calledBundle.calledMethodName);
         try {
             await classBundle.classToTest[classBundle.methodName](...classBundle.args);
         } catch {}
-        for (const argSet of calledBundle.expectedArgs || []) {
+        for (const argSet of expectedArgs || []) {
             expect(methodSpy).toHaveBeenCalledWith(...argSet);
         }
         return;
     };
     public static callsClassMethodWithArguments = (classBundle: ITestClassMethodBundle, calledBundle: ICalledClassMethodBundle): void => {
+        let expectedArgs;
+        if (calledBundle.expectedArgs) {
+            expectedArgs = validateTwoDimensionalArray(calledBundle.expectedArgs);
+        }
         const methodSpy = jest.spyOn(calledBundle.calledClass, calledBundle.calledMethodName);
         try {
             classBundle.classToTest[classBundle.methodName](...classBundle.args);
         } catch {}
-        for (const argSet of calledBundle.expectedArgs || []) {
+        for (const argSet of expectedArgs || []) {
             expect(methodSpy).toHaveBeenCalledWith(...argSet);
         }
         return;

--- a/src/testFunctionUsage.ts
+++ b/src/testFunctionUsage.ts
@@ -12,13 +12,14 @@ export class TestFunctionUsage {
         functionBundle: ITestFunctionBundle,
         calledBundle: ICalledFunctionBundle,
     ): Promise<void> => {
+        let expectedArgs;
         if (calledBundle.expectedArgs) {
-            validateTwoDimensionalArray(calledBundle.expectedArgs);
+            expectedArgs = validateTwoDimensionalArray(calledBundle.expectedArgs);
         }
         try {
             await functionBundle.functionToTest(...functionBundle.args);
         } catch {}
-        for (const argSet of calledBundle.expectedArgs || []) {
+        for (const argSet of expectedArgs || []) {
             expect(calledBundle.calledFunction).toHaveBeenCalledWith(...argSet);
         }
         return;
@@ -31,13 +32,14 @@ export class TestFunctionUsage {
         return;
     };
     public static callsFunctionWithArguments = (functionBundle: ITestFunctionBundle, calledBundle: ICalledFunctionBundle): void => {
+        let expectedArgs;
         if (calledBundle.expectedArgs) {
-            validateTwoDimensionalArray(calledBundle.expectedArgs);
+            expectedArgs = validateTwoDimensionalArray(calledBundle.expectedArgs);
         }
         try {
             functionBundle.functionToTest(...functionBundle.args);
         } catch {}
-        for (const argSet of calledBundle.expectedArgs || []) {
+        for (const argSet of expectedArgs || []) {
             expect(calledBundle.calledFunction).toHaveBeenCalledWith(...argSet);
         }
         return;
@@ -54,14 +56,15 @@ export class TestFunctionUsage {
         functionBundle: ITestFunctionBundle,
         calledBundle: ICalledClassMethodBundle,
     ): Promise<void> => {
+        let expectedArgs;
         if (calledBundle.expectedArgs) {
-            validateTwoDimensionalArray(calledBundle.expectedArgs);
+            expectedArgs = validateTwoDimensionalArray(calledBundle.expectedArgs);
         }
         const methodSpy = jest.spyOn(calledBundle.calledClass, calledBundle.calledMethodName);
         try {
             await functionBundle.functionToTest(...functionBundle.args);
         } catch {}
-        for (const argSet of calledBundle.expectedArgs || []) {
+        for (const argSet of expectedArgs || []) {
             expect(methodSpy).toHaveBeenCalledWith(...argSet);
         }
         return;
@@ -75,14 +78,15 @@ export class TestFunctionUsage {
         return;
     };
     public static callsClassMethodWithArguments = (functionBundle: ITestFunctionBundle, calledBundle: ICalledClassMethodBundle): void => {
+        let expectedArgs;
         if (calledBundle.expectedArgs) {
-            validateTwoDimensionalArray(calledBundle.expectedArgs);
+            expectedArgs = validateTwoDimensionalArray(calledBundle.expectedArgs);
         }
         const methodSpy = jest.spyOn(calledBundle.calledClass, calledBundle.calledMethodName);
         try {
             functionBundle.functionToTest(...functionBundle.args);
         } catch {}
-        for (const argSet of calledBundle.expectedArgs || []) {
+        for (const argSet of expectedArgs || []) {
             expect(methodSpy).toHaveBeenCalledWith(...argSet);
         }
         return;

--- a/src/testHelper.ts
+++ b/src/testHelper.ts
@@ -41,8 +41,7 @@ const determineTimesAndArguments = (timesOrArguments?: number | any[][]): ITimes
                 expectedArgs.push([]);
             }
         } else {
-            validateTwoDimensionalArray(timesOrArguments);
-            expectedArgs = timesOrArguments;
+            expectedArgs = validateTwoDimensionalArray(timesOrArguments);
             times = expectedArgs.length;
         }
     }

--- a/test/common/index.spec.ts
+++ b/test/common/index.spec.ts
@@ -1,23 +1,31 @@
 import { validateTwoDimensionalArray, TWO_DIMENSIONAL_ARRAY_ERROR, expectEquality } from '../../src/common';
 
 describe('When using the common function validateTwoDimensionalArray', () => {
-    test('if an empty, one-dimensional array is passed, no error is thrown', () => {
-        runErrorTest([], '');
+    test('if an empty, one-dimensional array is passed, no error is thrown and a modified array is returned', () => {
+        const result = runErrorTest([], '');
+        expectEquality(result, [[]]);
     });
-    test('if a two-dimensional array is passed, no error is thrown', () => {
-        runErrorTest([[]], '');
+    test('if a two-dimensional array is passed, no error is thrown and the original array is returned', () => {
+        const result = runErrorTest([[]], '');
+        expectEquality(result, [[]]);
     });
-    test('if a non-empty, one-dimensional array is passed, no error is thrown', () => {
-        runErrorTest(['testing', 1], TWO_DIMENSIONAL_ARRAY_ERROR);
+    test('if a non-empty, one-dimensional array is passed, no error is thrown and a modified array is returned', () => {
+        const result = runErrorTest(['testing', 1], '');
+        expectEquality(result, [['testing', 1]]);
+    });
+    test('if a non-empty array, with some elements being non-arrays is passed, the expected error is thrown', () => {
+        runErrorTest([['test', 1], ['check', 2], 'ooops', ['final', 3]], TWO_DIMENSIONAL_ARRAY_ERROR);
     });
 });
 
-const runErrorTest = (testArray: any | any[] | any[][], expectedMessage: string): void => {
+const runErrorTest = (testArray: any | any[] | any[][], expectedMessage: string): undefined | any[][] => {
     let message = '';
+    let result = undefined;
     try {
-        validateTwoDimensionalArray(testArray);
+        result = validateTwoDimensionalArray(testArray);
     } catch (error) {
         message = error.message;
     }
     expectEquality(message, expectedMessage);
+    return result;
 };


### PR DESCRIPTION
Function now returns the following based on the testArray argument:
- an empty array: empty Array<Array<>>
- a valid two-dimensional array:  testArray
- a one-dimensional array: Array<testArray>
- anything else continues to throw the original error